### PR TITLE
Refactor ThemeToggle to consume ThemeContext

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,34 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { useTheme } from '@mui/material/styles';
+import { ThemeContext } from '../contexts/ThemeContext';
 
 export default function ThemeToggle() {
   const theme = useTheme();
-  const [isDarkMode, setIsDarkMode] = useState(
-    () => localStorage.getItem('themeMode') === 'dark' || 
-    (!localStorage.getItem('themeMode') && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  );
-
-  useEffect(() => {
-    // Apply the theme
-    document.documentElement.setAttribute('data-theme', isDarkMode ? 'dark' : 'light');
-    localStorage.setItem('themeMode', isDarkMode ? 'dark' : 'light');
-    
-    // Dispatch event for other components that might need to react to theme changes
-    window.dispatchEvent(new CustomEvent('themechange', { 
-      detail: { theme: isDarkMode ? 'dark' : 'light' } 
-    }));
-  }, [isDarkMode]);
-
-  const toggleTheme = () => {
-    setIsDarkMode(prevMode => !prevMode);
-  };
+  const { isDarkMode, toggleTheme } = useContext(ThemeContext);
 
   return (
-    <IconButton 
-      onClick={toggleTheme} 
+    <IconButton
+      onClick={toggleTheme}
       color="inherit"
       aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
       sx={{

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -2,7 +2,7 @@ import React, { createContext, useState, useContext, useEffect } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
 import { lightTheme, darkTheme } from '../theme';
 
-const ThemeContext = createContext();
+export const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
   const [isDarkMode, setIsDarkMode] = useState(false);


### PR DESCRIPTION
## Summary
- use `ThemeContext` instead of local state inside `ThemeToggle`
- export `ThemeContext` so components can access it

## Testing
- `./run-tests.sh` *(fails: fetch failed)*