### PR TITLE
Use theme palette for backgrounds

### DIFF
--- a/src/components/AnalysisView.jsx
+++ b/src/components/AnalysisView.jsx
@@ -60,7 +60,10 @@ const AnalysisView = ({
               sx={{ 
                 p: 3, 
                 mb: 3, 
-                bgcolor: '#fff8e1', 
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.warning.dark
+                    : theme.palette.warning.light,
                 borderRadius: 2,
                 border: '1px solid #ffd54f',
                 display: 'flex',
@@ -107,9 +110,12 @@ const AnalysisView = ({
                 textAlign: 'center', 
                 cursor: 'pointer',
                 transition: 'all 0.2s',
-                '&:hover': { 
+                '&:hover': {
                   borderColor: 'primary.main',
-                  bgcolor: '#f8fafc' 
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.action.hover
+                      : '#f8fafc'
                 }
               }}
             >

--- a/src/components/DashboardView.jsx
+++ b/src/components/DashboardView.jsx
@@ -63,7 +63,12 @@ const DashboardView = ({ onUploadClick }) => {
                   border: '1px solid #e2e8f0', 
                   borderRadius: 2,
                   transition: 'all 0.2s',
-                  '&:hover': { bgcolor: '#f8fafc' }
+                  '&:hover': {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.action.hover
+                        : '#f8fafc'
+                  }
                 }}
               >
                 <ScoreBadge score={87} />
@@ -86,7 +91,12 @@ const DashboardView = ({ onUploadClick }) => {
                   border: '1px solid #e2e8f0', 
                   borderRadius: 2,
                   transition: 'all 0.2s',
-                  '&:hover': { bgcolor: '#f8fafc' }
+                  '&:hover': {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.action.hover
+                        : '#f8fafc'
+                  }
                 }}
               >
                 <ScoreBadge score={92} />
@@ -109,7 +119,12 @@ const DashboardView = ({ onUploadClick }) => {
                   border: '1px solid #e2e8f0', 
                   borderRadius: 2,
                   transition: 'all 0.2s',
-                  '&:hover': { bgcolor: '#f8fafc' }
+                  '&:hover': {
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.action.hover
+                        : '#f8fafc'
+                  }
                 }}
               >
                 <ScoreBadge score={76} />
@@ -140,9 +155,12 @@ const DashboardView = ({ onUploadClick }) => {
                 textAlign: 'center', 
                 cursor: 'pointer',
                 transition: 'all 0.2s',
-                '&:hover': { 
+                '&:hover': {
                   borderColor: 'primary.main',
-                  bgcolor: '#f8fafc' 
+                  bgcolor: (theme) =>
+                    theme.palette.mode === 'dark'
+                      ? theme.palette.action.hover
+                      : '#f8fafc'
                 }
               }}
             >
@@ -173,7 +191,15 @@ const DashboardView = ({ onUploadClick }) => {
               <Typography variant="h3" sx={{ mb: 2 }}>Performance Metrics</Typography>
               <Grid container spacing={2}>
                 <Grid item xs={6}>
-                  <Paper sx={{ bgcolor: '#f8fafc', borderRadius: 2, p: 2 }}>
+                  <Paper
+                    sx={{
+                      bgcolor: (theme) =>
+                        theme.palette.mode === 'dark'
+                          ? theme.palette.background.paper
+                          : '#f8fafc',
+                      borderRadius: 2,
+                      p: 2
+                    }}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <Typography variant="body2">Strategy Score</Typography>
                       <Badge variant="success">+12%</Badge>
@@ -183,7 +209,15 @@ const DashboardView = ({ onUploadClick }) => {
                 </Grid>
                 
                 <Grid item xs={6}>
-                  <Paper sx={{ bgcolor: '#f8fafc', borderRadius: 2, p: 2 }}>
+                  <Paper
+                    sx={{
+                      bgcolor: (theme) =>
+                        theme.palette.mode === 'dark'
+                          ? theme.palette.background.paper
+                          : '#f8fafc',
+                      borderRadius: 2,
+                      p: 2
+                    }}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <Typography variant="body2">Calls Analyzed</Typography>
                       <Badge variant="info">This Week</Badge>
@@ -206,7 +240,10 @@ const DashboardView = ({ onUploadClick }) => {
                 <Paper 
                   onClick={() => toggleSection('psychology')}
                   sx={{ 
-                    bgcolor: (theme) => theme.palette.mode === 'dark' ? 'background.paper' : '#f8fafc', 
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.background.paper
+                        : '#f8fafc',
                     borderRadius: 2, 
                     p: 2.5,
                     cursor: 'pointer',
@@ -335,7 +372,10 @@ const DashboardView = ({ onUploadClick }) => {
                 <Paper 
                   onClick={() => toggleSection('persuasion')}
                   sx={{ 
-                    bgcolor: (theme) => theme.palette.mode === 'dark' ? 'background.paper' : '#f8fafc', 
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.background.paper
+                        : '#f8fafc',
                     borderRadius: 2, 
                     p: 2.5,
                     cursor: 'pointer',
@@ -455,7 +495,10 @@ const DashboardView = ({ onUploadClick }) => {
                 <Paper 
                   onClick={() => toggleSection('strategic')}
                   sx={{ 
-                    bgcolor: (theme) => theme.palette.mode === 'dark' ? 'background.paper' : '#f8fafc', 
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? theme.palette.background.paper
+                        : '#f8fafc',
                     borderRadius: 2, 
                     p: 2.5,
                     cursor: 'pointer',

--- a/src/components/InsightsView.jsx
+++ b/src/components/InsightsView.jsx
@@ -31,7 +31,10 @@ const InsightsView = ({ analysisResults }) => {
             <Box
               sx={{
                 p: 3,
-                bgcolor: '#fff8e1',
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.warning.dark
+                    : theme.palette.warning.light,
                 borderRadius: 2,
                 border: '1px solid #ffd54f',
                 display: 'flex',


### PR DESCRIPTION
## Summary
- reference theme palette instead of hard-coded colors for banner and paper backgrounds
- adjust hover colors in Dashboard and Analysis views to work in both light and dark modes

## Testing
- `bash run-tests.sh <<'EOF'
n
EOF` *(fails: fetch failed)*